### PR TITLE
add clean view configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,17 @@
         "key": "alt+left",
         "when": "editorLangId == org"
       }
-    ]
+    ],
+    "configuration": {
+      "title": "Org Lite",
+      "properties": {
+        "org-lite.outline.cleanView": {
+          "type": "boolean",
+          "default": false,
+          "description": "Clean view mode for outline"
+        }
+      }
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",

--- a/syntaxes/org.tmLanguage.json
+++ b/syntaxes/org.tmLanguage.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
   "name": "Org",
   "scopeName": "source.org",
-  "patterns": [{ "include": "#heading" }],
+  "patterns": [{ "include": "#heading" }, { "include": "#indented-heading" }],
   "repository": {
     "heading": {
       "patterns": [
@@ -56,6 +56,64 @@
           "match": "^(\\*{6})\\s+(?:(TODO)\\s+)?(.*?)$",
           "captures": {
             "2": {
+              "name": "keyword.control.todo.org"
+            }
+          }
+        }
+      ]
+    },
+    "indented-heading": {
+      "patterns": [
+        {
+          "name": "heading.1.markdown",
+          "match": "^(\\*)\\s+(?:(TODO)\\s+)?(.*?)$",
+          "captures": {
+            "3": {
+              "name": "keyword.control.todo.org"
+            }
+          }
+        },
+        {
+          "name": "heading.2.markdown",
+          "match": "^(  )(\\*+)\\s+(?:(TODO)\\s+)?(.*?)$",
+          "captures": {
+            "3": {
+              "name": "keyword.control.todo.org"
+            }
+          }
+        },
+        {
+          "name": "heading.3.markdown",
+          "match": "^(    )(\\*+)\\s+(?:(TODO)\\s+)?(.*?)$",
+          "captures": {
+            "3": {
+              "name": "keyword.control.todo.org"
+            }
+          }
+        },
+        {
+          "name": "heading.4.markdown",
+          "match": "^(      )(\\*+)\\s+(?:(TODO)\\s+)?(.*?)$",
+          "captures": {
+            "3": {
+              "name": "keyword.control.todo.org"
+            }
+          }
+        },
+        {
+          "name": "heading.5.markdown",
+          "match": "^(        )(\\*+)\\s+(?:(TODO)\\s+)?(.*?)$",
+          "captures": {
+            "3": {
+              "name": "keyword.control.todo.org"
+            }
+          }
+        },
+        {
+          "name": "heading.6.markdown",
+          "match": "^(          )(\\*+)\\s+(?:(TODO)\\s+)?(.*?)$",
+          "captures": {
+            "3": {
               "name": "keyword.control.todo.org"
             }
           }


### PR DESCRIPTION
### Summary
Adds a clean view mode for Org files that provides enhanced outline support and dynamic syntax highlighting.

### Features
* Clean View Setting: Added `org-lite.outline.cleanView` configuration option
* Enhanced Outline: Support for indented headings in clean view mode