### PR TITLE
add hyperlink support for org files

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,9 @@
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
 import { showAgendaView } from './orgAgendaView';
+import { OrgDocumentLinkProvider } from './orgDocumentLinkProvider';
 import { OrgDocumentSymbolProvider } from './orgDocumentSymbolProvider';
+import { OrgPathCompletionProvider } from './orgPathCompletionProvider';
 import { OrgTableManager } from './orgTableManager';
 import { OrgTaskManager } from './orgTaskManager';
 
@@ -28,7 +30,20 @@ export function activate(context: vscode.ExtensionContext) {
   );
 
   // Push all disposables at once for clarity
-  context.subscriptions.push(documentSymbolProvider, showAgendaCommand);
+  context.subscriptions.push(
+    documentSymbolProvider,
+    showAgendaCommand,
+    vscode.languages.registerDocumentLinkProvider(
+      { language: 'org' },
+      new OrgDocumentLinkProvider()
+    ),
+    vscode.languages.registerCompletionItemProvider(
+      'org',
+      new OrgPathCompletionProvider(),
+      '[',
+      '/'
+    )
+  );
 }
 
 // This method is called when your extension is deactivated

--- a/src/orgDocumentLinkProvider.ts
+++ b/src/orgDocumentLinkProvider.ts
@@ -1,0 +1,30 @@
+import * as vscode from 'vscode';
+
+export class OrgDocumentLinkProvider implements vscode.DocumentLinkProvider {
+  provideDocumentLinks(document: vscode.TextDocument): vscode.DocumentLink[] {
+    const links: vscode.DocumentLink[] = [];
+    const regex = /\[\[([^\]]+)\]\]/g;
+    for (let line = 0; line < document.lineCount; line++) {
+      const text = document.lineAt(line).text;
+      let match: RegExpExecArray | null;
+      while ((match = regex.exec(text))) {
+        const linkText = match[1];
+        const start = match.index + 2;
+        const end = start + linkText.length;
+        const range = new vscode.Range(line, start, line, end);
+        let uri: vscode.Uri;
+        if (/^https?:\/\//.test(linkText)) {
+          // Open http(s) links in the browser
+          uri = vscode.Uri.parse(linkText);
+        } else {
+          // Interpret as a file path
+          uri = vscode.Uri.file(
+            require('path').resolve(document.uri.fsPath, '..', linkText)
+          );
+        }
+        links.push(new vscode.DocumentLink(range, uri));
+      }
+    }
+    return links;
+  }
+}

--- a/src/orgPathCompletionProvider.ts
+++ b/src/orgPathCompletionProvider.ts
@@ -1,0 +1,38 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+export class OrgPathCompletionProvider
+  implements vscode.CompletionItemProvider
+{
+  provideCompletionItems(
+    document: vscode.TextDocument,
+    position: vscode.Position
+  ) {
+    const line = document.lineAt(position.line).text;
+    const prefix = line.slice(0, position.character);
+    // Check if it starts with [[ or is immediately after [[
+    const match = prefix.match(/\[\[([^\]]*)$/);
+    if (!match) return;
+
+    const inputPath = match[1] || '';
+    const baseDir = path.dirname(document.uri.fsPath);
+    const absDir = path.resolve(baseDir, inputPath.replace(/[^/\\]*$/, ''));
+    if (!fs.existsSync(absDir) || !fs.statSync(absDir).isDirectory()) return;
+
+    const items: vscode.CompletionItem[] = [];
+    for (const file of fs.readdirSync(absDir)) {
+      const filePath = path.join(absDir, file);
+      const isDir = fs.statSync(filePath).isDirectory();
+      const item = new vscode.CompletionItem(
+        file + (isDir ? '/' : ''),
+        isDir
+          ? vscode.CompletionItemKind.Folder
+          : vscode.CompletionItemKind.File
+      );
+      item.insertText = file + (isDir ? '/' : '');
+      items.push(item);
+    }
+    return items;
+  }
+}

--- a/syntaxes/org.tmLanguage.json
+++ b/syntaxes/org.tmLanguage.json
@@ -2,7 +2,11 @@
   "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
   "name": "Org",
   "scopeName": "source.org",
-  "patterns": [{ "include": "#heading" }, { "include": "#bold" }],
+  "patterns": [
+    { "include": "#heading" },
+    { "include": "#bold" },
+    { "include": "#link" }
+  ],
   "repository": {
     "heading": {
       "patterns": [
@@ -67,6 +71,14 @@
         {
           "name": "markup.bold",
           "match": "\\*(.*?)\\*"
+        }
+      ]
+    },
+    "link": {
+      "patterns": [
+        {
+          "name": "markup.underline.link.org",
+          "match": "\\[\\[[^\\]]+\\]\\]"
         }
       ]
     }


### PR DESCRIPTION
### Summary
* Added syntax highlighting for `[[LINK]]` -style hyperlinks in org files.
* Implemented a DocumentLinkProvider to detect `[[LINK]]` patterns and make them clickable.
* If the link is a file path, Ctrl+Click opens the file in the editor.
* If the link starts with `http:` or `https:`, Ctrl+Click opens it in the browser using VS Code's standard webview.
* Improved user experience for navigating and referencing files and URLs in org-mode documents.